### PR TITLE
feat: implement query parameter extraction service

### DIFF
--- a/services/query_extractor.py
+++ b/services/query_extractor.py
@@ -1,0 +1,68 @@
+# WORKFLOW: LLM service for extracting query parameters from natural language messages.
+# Used by: Chat endpoints for parameter extraction.
+# Functions:
+# 1. extract_query_parameters() - Parse user message to origin, destination, product description, quantity.
+#
+# Extraction flow: User message -> LLM prompt -> JSON response -> Validation -> Parameter dict
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any, Dict
+
+import ollama
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+client = ollama.Client(host=settings.ollama_url)
+
+PROMPT_TEMPLATE = """
+Extract the origin country, destination country, product description, and quantity from the following message.
+Return ONLY a JSON object with keys: origin, destination, product_description, quantity (number or null).
+
+Message: {message}
+JSON:
+"""
+
+
+async def extract_query_parameters(message: str) -> Dict[str, Any]:
+    """Extract query parameters from a user message using LLM."""
+    prompt = PROMPT_TEMPLATE.format(message=message)
+
+    def _call_llm() -> Dict[str, Any]:
+        return client.generate(model=settings.llm_model, prompt=prompt)
+
+    try:
+        response = await asyncio.to_thread(_call_llm)
+        data = json.loads(response.get("response", "{}"))
+
+        origin = data.get("origin", "")
+        destination = data.get("destination", "")
+        product_description = data.get("product_description", "")
+        quantity_raw = data.get("quantity")
+
+        quantity = None
+        if isinstance(quantity_raw, str):
+            match = re.search(r"\d+", quantity_raw)
+            if match:
+                quantity = int(match.group())
+        elif isinstance(quantity_raw, (int, float)):
+            quantity = int(quantity_raw)
+
+        if not isinstance(origin, str) or not isinstance(destination, str) or not isinstance(product_description, str):
+            raise ValueError("Invalid field types")
+
+        return {
+            "origin": origin,
+            "destination": destination,
+            "product_description": product_description,
+            "quantity": quantity,
+        }
+    except Exception as e:
+        logger.error(f"Failed to extract query parameters: {e}")
+        return {"origin": "", "destination": "", "product_description": "", "quantity": None}

--- a/tests/test_query_parameters.py
+++ b/tests/test_query_parameters.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+
+from services.query_extractor import extract_query_parameters
+
+
+@pytest.mark.asyncio
+async def test_multi_country_extraction(monkeypatch):
+    """Ensure extraction works when multiple countries are mentioned."""
+
+    def mock_generate(*args, **kwargs):
+        return {
+            "response": json.dumps({
+                "origin": "Pakistan",
+                "destination": "Germany",
+                "product_description": "cotton shirts",
+                "quantity": 5,
+            })
+        }
+
+    monkeypatch.setattr("services.query_extractor.client.generate", mock_generate)
+
+    result = await extract_query_parameters(
+        "Ship 5 cotton shirts from Pakistan to Germany via France"
+    )
+
+    assert result["origin"] == "Pakistan"
+    assert result["destination"] == "Germany"
+    assert result["product_description"] == "cotton shirts"
+    assert result["quantity"] == 5
+
+
+@pytest.mark.asyncio
+async def test_unit_based_quantity(monkeypatch):
+    """Extract numeric quantity from unit-based phrasing."""
+
+    def mock_generate(*args, **kwargs):
+        return {
+            "response": json.dumps({
+                "origin": "US",
+                "destination": "UK",
+                "product_description": "steel rods",
+                "quantity": "10 tons",
+            })
+        }
+
+    monkeypatch.setattr("services.query_extractor.client.generate", mock_generate)
+
+    result = await extract_query_parameters(
+        "Export 10 tons of steel rods from the US to the UK"
+    )
+
+    assert result["quantity"] == 10
+    assert result["origin"] == "US"
+    assert result["destination"] == "UK"
+    assert result["product_description"] == "steel rods"


### PR DESCRIPTION
## Summary
- add LLM-powered query extraction service for origin, destination, description and quantity
- replace regex extraction in chat router
- test query extractor for multi-country and unit phrases

## Testing
- `ruff check services/query_extractor.py api/routers/chat.py tests/test_query_parameters.py`
- `PYTHONPATH=. pytest tests/test_query_parameters.py`


------
https://chatgpt.com/codex/tasks/task_e_68aceeefacec832f91308f5421adff76