### PR TITLE
Mock LLM for query parameter tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ python -m pytest tests/test_workflow.py -v
 python -m pytest tests/ --cov=. --cov-report=html
 ```
 
+The test suite stubs out calls to the Ollama LLM so no external model is
+invoked. See `tests/test_query_parameters.py` for the mocking helper used to
+return deterministic JSON payloads.
+
 ### Test the Cotton Hoodie Workflow
 ```bash
 # This test validates the complete workflow from the requirements


### PR DESCRIPTION
## Summary
- patch query parameter tests to stub Ollama and pydantic_settings modules
- add helper to mock LLM response and cover multi-origin and unit quantity cases
- document offline LLM mocking in README

## Testing
- `ruff check tests/test_query_parameters.py`
- `PYTHONPATH=. pytest tests/test_query_parameters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acf02879b8832f9895a0eaf93e6e8b